### PR TITLE
[chore][devx] let rde show up for cypress tests too

### DIFF
--- a/src/codelensprovider.ts
+++ b/src/codelensprovider.ts
@@ -51,9 +51,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
       const text = document.getText();
       const parseResults = parse(document.fileName, text).root.children ?? [];
       const codeLens: CodeLens[] = [];
-      if (!document.uri.fsPath.includes("frontend/cypress/")) {
-        parseResults.forEach((parseResult) => codeLens.push(...getTestsBlocks(parseResult, parseResults)));
-      }
+      parseResults.forEach((parseResult) => codeLens.push(...getTestsBlocks(parseResult, parseResults)));
       return codeLens;
     } catch (e) {
       // Ignore error and keep showing Run/Debug buttons at same position


### PR DESCRIPTION
rde now works for e2e cypress tests too. This just makes the button show up for the extension